### PR TITLE
GPII-1318: Fixed errors uncovered from assertDeepEq now differentiati…

### DIFF
--- a/gpii/node_modules/ontologyHandler/src/ontologyHandlerUtilities.js
+++ b/gpii/node_modules/ontologyHandler/src/ontologyHandlerUtilities.js
@@ -81,7 +81,7 @@ gpii.ontologyHandler.utils.filter = function (source, remove) {
 gpii.ontologyHandler.utils.filterPrefs = function (fullSet, toRemove) {
     var cpy = fluid.copy(fullSet);
     var result = gpii.ontologyHandler.utils.filter(cpy, toRemove);
-    return result;
+    return result === undefined ? {} : result;
 };
 
 // Transforms required for application specific settings

--- a/gpii/node_modules/transformer/test/js/TransformerTests.js
+++ b/gpii/node_modules/transformer/test/js/TransformerTests.js
@@ -537,7 +537,9 @@ fluid.setLogging(true);
                         }, {
                             "upperBound": 600,
                             "output": {
-                                bar: "DOGG"
+                                literalValue: {
+                                    bar: "DOGG"
+                                }
                             }
                         }, {
                             "output": 3
@@ -604,9 +606,11 @@ fluid.setLogging(true);
         },
         fixtures: {
             "undefined check": {
+                expected: {}
             },
             "NaN check": {
-                input: NaN // warning, this fixture not valid for JSON interchange
+                input: NaN, // warning, this fixture not valid for JSON interchange
+                expected: {}
             },
             "single value check": {
                 input: 6,


### PR DESCRIPTION
…ng between undefined and {}. Also a minor fix due to a change in semantics of the model transformation framework which causes the 'output' of a quantize to be interpreted as a transform by default
